### PR TITLE
update: add block to transfer types, updated docker to include ganache

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -11,6 +11,7 @@ services:
     depends_on:
       - ipfs
       - postgres
+      - ganache
     extra_hosts:
       - host.docker.internal:host-gateway
     environment:
@@ -28,6 +29,11 @@ services:
       - '5001:5001'
     volumes:
       - ./data/ipfs:/data/ipfs
+  ganache:
+    image: trufflesuite/ganache-cli
+    ports:
+      - '8545:8545'
+    command: -i 15 --gasLimit 8000000 --deterministic
   postgres:
     image: postgres
     ports:

--- a/schema.graphql
+++ b/schema.graphql
@@ -215,6 +215,7 @@ type ERC721Transfer implements Event @entity(immutable: true) {
   id: ID!
   emitter: Account!
   transaction: Transaction!
+  block: Block!
   timestamp: BigInt!
   contract: ERC721Contract!
   token: ERC721Token!
@@ -341,6 +342,7 @@ type ERC1155Transfer implements Event @entity(immutable: true) {
   emitter: Account!
   transaction: Transaction!
   timestamp: BigInt!
+  block: Block!
   contract: ERC1155Contract!
   token: ERC1155Token!
   operator: Account!


### PR DESCRIPTION
While compiling and deploying subgraph, had to add block to the ERC721Transfer and ERC1155Transfer types

Added ganache to the docker-compose file